### PR TITLE
Replace many typecasts with safer type narrowing

### DIFF
--- a/src/logic/deck.ts
+++ b/src/logic/deck.ts
@@ -8,7 +8,8 @@ export enum Suit {
 	Hearts = 3,
 }
 
-export type CardValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
+const cardValues = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] as const;
+export type CardValue = (typeof cardValues)[number];
 
 const faces = [
 	"NIL",
@@ -124,13 +125,13 @@ export class Deck<T> extends Array<T> {
 		const deck = new Deck<Card>(52);
 		let i = 0;
 		for (const suit of [Suit.Spades, Suit.Diamonds]) {
-			for (let v = 1; v <= 13; v++) {
-				deck[i++] = new Card(suit, v as CardValue);
+			for (const v of cardValues) {
+				deck[i++] = new Card(suit, v);
 			}
 		}
 		for (const suit of [Suit.Clubs, Suit.Hearts]) {
-			for (let v = 13; v > 0; v--) {
-				deck[i++] = new Card(suit, v as CardValue);
+			for (const v of [...cardValues].reverse()) {
+				deck[i++] = new Card(suit, v);
 			}
 		}
 
@@ -138,8 +139,8 @@ export class Deck<T> extends Array<T> {
 	}
 	static ofSuit(suit: Suit) {
 		const deck = new Deck<Card>(13);
-		for (let v = 1; v <= 13; v++) {
-			deck[v - 1] = new Card(suit, v as CardValue);
+		for (const v of cardValues) {
+			deck[v - 1] = new Card(suit, v);
 		}
 
 		return deck;

--- a/src/logic/undo-stack.ts
+++ b/src/logic/undo-stack.ts
@@ -1,5 +1,8 @@
 interface SerializedDelta {f?: unknown; t?: unknown}
-type Collection = Partial<Record<string, unknown>> | unknown[];
+type Collection = Partial<{
+	[x: number | string]: unknown;
+	length?: number;
+}>;
 
 class Delta<T> {
 	constructor(public from: T, public to: T) {}
@@ -13,17 +16,14 @@ class Delta<T> {
 		const from: Collection | null = prevState == null ? null : {};
 		const to: Collection | null = nextState == null ? null : {};
 
-		// cast to record so typescript doesn't complain about string indexes
-		const prevRecord = prevState as Record<string, unknown> | null;
-		const nextRecord = nextState as Record<string, unknown> | null;
 		const allKeys = new Set(
 			Object.getOwnPropertyNames(prevState ?? {})
 				.concat(Object.getOwnPropertyNames(nextState ?? {})),
 		);
 
 		for (const key of allKeys) {
-			const prev = prevRecord?.[key] ?? null;
-			const next = nextRecord?.[key] ?? null;
+			const prev = prevState?.[key] ?? null;
+			const next = nextState?.[key] ?? null;
 
 			if (prev === next) {
 				continue;

--- a/src/ui/free-cell/board.tsx
+++ b/src/ui/free-cell/board.tsx
@@ -71,7 +71,11 @@ function useGame() {
 	}, []);
 
 	const targetTap = useCallback((targetContext: Deck<Card>) => {
-		const activeElement = document.activeElement as HTMLElement;
+		const activeElement = document.activeElement;
+		if (!(activeElement instanceof HTMLElement)) {
+			return false;
+		}
+
 		const activeCard = getCard(activeElement);
 		if (activeCard != null && game.canMoveCards(activeCard, targetContext)) {
 			doMoveCards(activeCard, targetContext);

--- a/src/ui/klondike/board.tsx
+++ b/src/ui/klondike/board.tsx
@@ -122,7 +122,11 @@ function useGame() {
 	const playableGetCards = useCallback((card: Card) => game.getMovableCards(card), []);
 
 	const targetTap = useCallback((targetContext: Deck<Card>) => {
-		const activeElement = document.activeElement as HTMLElement;
+		const activeElement = document.activeElement;
+		if (!(activeElement instanceof HTMLElement)) {
+			return false;
+		}
+
 		const activeCard = getCard(activeElement);
 		if (activeCard != null && game.canMoveCards(activeCard, targetContext)) {
 			doMoveCards(activeCard, targetContext);

--- a/src/ui/klondike/board.tsx
+++ b/src/ui/klondike/board.tsx
@@ -100,7 +100,10 @@ function useGame() {
 	});
 
 	const drawPileTap = enqueueAction(function*(pointer: Pointer) {
-		(document.activeElement as HTMLElement).blur();
+		if (document.activeElement instanceof HTMLElement) {
+			document.activeElement.blur();
+		}
+
 		const context = pointer.card.meta.context as Deck<Card>;
 		if (pointer.card === context.fromTop()) {
 			const commit = undoStack.record(game);

--- a/src/ui/pyramid/board.tsx
+++ b/src/ui/pyramid/board.tsx
@@ -59,9 +59,9 @@ function useGame() {
 		}
 	});
 
-	const onDrop = useCallback((pointer: Pointer, _: unknown, targetCard: unknown) => {
-		if (targetCard != null && game.canClearCards(pointer.card, targetCard as Card)) {
-			doClearCards(pointer.card, targetCard as Card);
+	const onDrop = useCallback((pointer: Pointer, _: unknown, targetCard: Card | undefined) => {
+		if (targetCard != null && game.canClearCards(pointer.card, targetCard)) {
+			doClearCards(pointer.card, targetCard);
 		}
 	}, []);
 
@@ -83,8 +83,10 @@ function useGame() {
 	});
 
 	const drawPileDraw = enqueueAction(function*() {
-		const activeElement = document.activeElement as HTMLElement;
-		activeElement.blur();
+		if (document.activeElement instanceof HTMLElement) {
+			document.activeElement.blur();
+		}
+
 		const commit = undoStack.record(game);
 		if (game.drawPile.length > 0) {
 			game.drawCard();
@@ -100,7 +102,11 @@ function useGame() {
 	const playableGetCards = useCallback((card: Card) => game.getMovableCards(card), []);
 
 	const playableTap = useCallback((pointer: Pointer) => {
-		const activeElement = document.activeElement as HTMLElement;
+		const activeElement = document.activeElement;
+		if (!(activeElement instanceof HTMLElement)) {
+			return;
+		}
+
 		const activeCard = getCard(activeElement);
 		if (activeCard != null && game.canClearCards(activeCard, pointer.card)) {
 			doClearCards(activeCard, pointer.card);

--- a/src/ui/shared/get-context.ts
+++ b/src/ui/shared/get-context.ts
@@ -32,14 +32,18 @@ export function getCard(elem: Element) {
 	return null;
 }
 
+function isType<T extends FC<any>>(fiber: Fiber<any> | null, type: T): fiber is Fiber<T> {
+	return fiber?.type === type;
+}
+
 export function getContextAndCard(elem: Element) {
 	const fiber = getComponentFiber(elem, [Card, EmptyZone]);
-	if (fiber?.type === Card) {
-		const props = fiber.memoizedProps as ExtractPropTypes<typeof Card>;
+	if (isType(fiber, Card)) {
+		const props = fiber.memoizedProps;
 		return [props.card.meta.context, props.card] as const;
 	}
-	if (fiber?.type === EmptyZone) {
-		const props = fiber.memoizedProps as ExtractPropTypes<typeof EmptyZone>;
+	if (isType(fiber, EmptyZone)) {
+		const props = fiber.memoizedProps;
 		return [props.context] as const;
 	}
 

--- a/src/ui/shared/modal.tsx
+++ b/src/ui/shared/modal.tsx
@@ -7,11 +7,19 @@ function takeWhere<T>(array: T[], predicate: (x: T) => boolean) {
 }
 
 function typeIs(node: ReactNode, Type: FC<any>) {
-	return (node as {type?: FC} | null)?.type === Type;
+	return node != null && typeof node === "object" && "type" in node && node.type === Type;
+}
+
+function arrayWrap<T>(v: T | T[]) {
+	if (v instanceof Array) {
+		return [...v];
+	}
+
+	return [v];
 }
 
 export function Modal({children}: {children: ReactNode}) {
-	const wrapped = children instanceof Array ? [...children as ReactNode[]] : [children];
+	const wrapped = arrayWrap(children);
 	const header = takeWhere(wrapped, (c) => typeIs(c, ModalHeader));
 	const footer = takeWhere(wrapped, (c) => typeIs(c, ModalFooter));
 

--- a/src/ui/shared/sizerator.tsx
+++ b/src/ui/shared/sizerator.tsx
@@ -1,7 +1,5 @@
 import {ComponentType, createContext, useCallback, useContext, useEffect, useState} from "react";
 
-type PropsOf<C> = C extends ComponentType<infer P> ? P extends object ? P : {} : never;
-
 const SizeContext = createContext({
 	margins: 0, cardWidth: 0, cardHeight: 0,
 	cardOffsetX: 0, cardOffsetY: 0,
@@ -10,13 +8,13 @@ const SizeContext = createContext({
 
 const cardRatio = 1.5;
 
-export function sizerated<C extends ComponentType<any>>(
+export function sizerated<P extends {}>(
 	cardsAcross: number,
 	cardsTall:
 	number,
-	Component: C,
+	Component: ComponentType<P>,
 ) {
-	return function Sizerator(props: PropsOf<C>) {
+	return function Sizerator(props: P) {
 		const computeSizes = useCallback(() => {
 			const {clientWidth: width, clientHeight: height} = document.documentElement;
 			const margins = width < 600 ? 5 : 10;

--- a/src/ui/shared/sizerator.tsx
+++ b/src/ui/shared/sizerator.tsx
@@ -1,5 +1,7 @@
 import {ComponentType, createContext, useCallback, useContext, useEffect, useState} from "react";
 
+type PropsOf<C> = C extends ComponentType<infer P> ? P extends object ? P : {} : never;
+
 const SizeContext = createContext({
 	margins: 0, cardWidth: 0, cardHeight: 0,
 	cardOffsetX: 0, cardOffsetY: 0,
@@ -14,7 +16,7 @@ export function sizerated<C extends ComponentType<any>>(
 	number,
 	Component: C,
 ) {
-	return function Sizerator(props: any) {
+	return function Sizerator(props: PropsOf<C>) {
 		const computeSizes = useCallback(() => {
 			const {clientWidth: width, clientHeight: height} = document.documentElement;
 			const margins = width < 600 ? 5 : 10;

--- a/src/ui/spider/board.tsx
+++ b/src/ui/spider/board.tsx
@@ -81,8 +81,9 @@ function useGame() {
 	}, []);
 
 	const drawPileTap = enqueueAction(function*() {
-		const activeElement = document.activeElement as HTMLElement;
-		activeElement.blur();
+		if (document.activeElement instanceof HTMLElement) {
+			document.activeElement.blur();
+		}
 
 		if (game.tableau.every((d) => d.length > 0)) {
 			const commit = undoStack.record(game);
@@ -103,7 +104,11 @@ function useGame() {
 	const playableGetCards = useCallback((card: Card) => game.getMovableCards(card), []);
 
 	const targetTap = useCallback((targetContext: Deck<Card>) => {
-		const activeElement = document.activeElement as HTMLElement;
+		const activeElement = document.activeElement;
+		if (!(activeElement instanceof HTMLElement)) {
+			return false;
+		}
+
 		const activeCard = getCard(activeElement);
 		if (activeCard != null && game.canMoveCards(activeCard, targetContext)) {
 			doMoveCards(activeCard, targetContext);

--- a/src/ui/wish/board.tsx
+++ b/src/ui/wish/board.tsx
@@ -56,7 +56,11 @@ function useGame() {
 	const playableGetCards = useCallback((card: Card) => game.getMovableCards(card), []);
 
 	const playableTap = useCallback((pointer: Pointer) => {
-		const activeElement = document.activeElement as HTMLElement;
+		const activeElement = document.activeElement;
+		if (!(activeElement instanceof HTMLElement)) {
+			return;
+		}
+
 		const activeCard = getCard(activeElement);
 		if (activeCard != null && game.canClearCards(activeCard, pointer.card)) {
 			doClearCards(activeCard, pointer.card);


### PR DESCRIPTION
Trying to clean up some blind typecasts I used during the migration into safer forms that rely on type narrowing.
There are still many casts remaining, but they'll require some more significant refactoring.